### PR TITLE
Update threejs and itowns versions

### DIFF
--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -8,7 +8,7 @@
     "doc": "jsdoc Main.js",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint",
-    "build": "webpack -p",
+    "build": "webpack",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
     "//": "\"prepublish\": \"npm run build && npm run transpile\""
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.14.0",
+    "itowns": "2.15.3",
     "moment": "^2.19.0",
     "proj4": "^2.5.0",
-    "three": "^0.108.0"
+    "three": "^0.109.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
Bump itowns to v1.15.3 and threejs to v0.109.

Updating threejs caused `npm run build` (used for production deployment on our servers) to trigger the following error:

````
ERROR in udvcore.js from UglifyJs
Unexpected token: name (BoxGeometry) [./node_modules/three/build/three.module.js:12592,0][udvcore.js:18798,6]
````

In our case, `npm run build` is a macro for `webpack -p` ([see package.json](https://github.com/VCityTeam/UD-Viz/blob/master/UD-Viz-Core/package.json#L11). The `-p` option stands for "production" which set flags for code minification and tree shaking (see [this tutorial](https://webpack.js.org/guides/production/#setup)). 

This specific error is caused by Uglifyjs which takes care of minification and it is related to threejs moving BoxGeometry to ES6 classes (see [this migration guide](https://github.com/mrdoob/three.js/wiki/Migration-Guide#r108--r109)).

Removing the `-p` option of `npm run build` still allows deployment and removes the error. It may produce a bit bigger udvcore.js bundle but we are not yet at this level of optimization.

Note that these are not the last versions of itowns and threejs; i will propose an update in another PR.