### PR TITLE
Packages update

### DIFF
--- a/UD-Viz-Core/examples/data/config/generalDemoConfig.json
+++ b/UD-Viz-Core/examples/data/config/generalDemoConfig.json
@@ -114,7 +114,7 @@
   "3DTilesLayer":{
     "building":{
       "id":"3d-tiles-layer-building",
-      "url":"http://localhost:8003/tilesets/Lyon2015-gltf-repaired-6/tileset.json",
+      "url":"http://rict2.liris.cnrs.fr/DataStore/Lyon-2015-gltf-repaired/tileset.json",
       "color": "0xFFFFFF",
       "initTilesManager": "true"
     },

--- a/UD-Viz-Core/examples/data/config/generalDemoConfig.json
+++ b/UD-Viz-Core/examples/data/config/generalDemoConfig.json
@@ -13,7 +13,7 @@
       "file": "file",
       "guidedTour": "guidedTour",
       "link": "link"
-    },    
+    },
     "lyon_stable": {
       "url": "http://rict.liris.cnrs.fr:443/",
       "login": "login",
@@ -114,7 +114,7 @@
   "3DTilesLayer":{
     "building":{
       "id":"3d-tiles-layer-building",
-      "url":"http://rict.liris.cnrs.fr/DataStore/TileSet_LyonFull_Villeurbanne_Bron_2015/tileset.json",
+      "url":"http://localhost:8003/tilesets/Lyon2015-gltf-repaired-6/tileset.json",
       "color": "0xFFFFFF",
       "initTilesManager": "true"
     },

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.16.0",
+    "itowns": "2.17.0",
     "moment": "^2.19.0",
-    "proj4": "^2.5.0",
-    "three": "^0.109.0"
+    "proj4": "^2.6.0",
+    "three": "^0.110.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.19.0",
+    "itowns": "2.20.0",
     "moment": "^2.19.0",
-    "proj4": "^2.6.0",
-    "three": "^0.113.2"
+    "proj4": "^2.6.2",
+    "three": "^0.114.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.18.0",
+    "itowns": "2.19.0",
     "moment": "^2.19.0",
     "proj4": "^2.6.0",
-    "three": "^0.112.1"
+    "three": "^0.113.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.22.0",
+    "itowns": "2.23.0",
     "moment": "^2.19.0",
     "proj4": "^2.6.2",
-    "three": "^0.116.1"
+    "three": "^0.117.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.21.0",
+    "itowns": "2.22.0",
     "moment": "^2.19.0",
-    "proj4": "^2.6.1",
-    "three": "^0.115.0"
+    "proj4": "^2.6.2",
+    "three": "^0.116.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.15.3",
+    "itowns": "2.16.0",
     "moment": "^2.19.0",
     "proj4": "^2.5.0",
     "three": "^0.109.0"

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.20.0",
+    "itowns": "2.21.0",
     "moment": "^2.19.0",
-    "proj4": "^2.6.2",
-    "three": "^0.114.0"
+    "proj4": "^2.6.1",
+    "three": "^0.115.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.17.0",
+    "itowns": "2.18.0",
     "moment": "^2.19.0",
     "proj4": "^2.6.0",
-    "three": "^0.110.0"
+    "three": "^0.112.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingView.js
+++ b/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingView.js
@@ -130,7 +130,7 @@ export class GeocodingView extends ModuleView {
   getWorldCoordinates(lat, lng) {
     const [targetX, targetY] = proj4('EPSG:3946').forward([lng, lat]);
     const coords = new Coordinates('EPSG:3946', targetX, targetY, 0);
-    const elevation = itowns.DEMUtils.getElevationValueAt(this.planarView.tileLayer, coords);
+    const elevation = itowns.DEMUtils.getTerrainObjectAt(this.planarView.tileLayer, coords);
     const targetZ = (!!elevation) ? elevation.z : undefined;
     return new THREE.Vector3(targetX, targetY, targetZ);
   }

--- a/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingView.js
+++ b/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingView.js
@@ -130,8 +130,8 @@ export class GeocodingView extends ModuleView {
   getWorldCoordinates(lat, lng) {
     const [targetX, targetY] = proj4('EPSG:3946').forward([lng, lat]);
     const coords = new Coordinates('EPSG:3946', targetX, targetY, 0);
-    const elevation = itowns.DEMUtils.getTerrainObjectAt(this.planarView.tileLayer, coords);
-    const targetZ = (!!elevation) ? elevation.z : undefined;
+    const elevation = itowns.DEMUtils.getElevationValueAt(this.planarView.tileLayer, coords);
+    const targetZ = (!!elevation) ? elevation : undefined;
     return new THREE.Vector3(targetX, targetY, targetZ);
   }
 

--- a/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -564,8 +564,8 @@ export function getTilesInfo(layer, tilesInfo = null) {
     tilesInfo.tiles = {};
     tilesInfo.tileset;
   }
-  let tileIndex = layer.tileIndex;
-  let tileCount = Object.keys(tileIndex.index).length - 1; // -1 because of the
+  let tileset = layer.tileset;
+  let tileCount = Object.keys(tileset.tiles).length - 1; // -1 because of the
                                                            // root tile
   tilesInfo.totalTileCount = tileCount;
   let rootTile = layer.object3d.children[0];

--- a/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -168,7 +168,7 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
   }
 
   //We need to use the color of the vertices, not the material
-  tile.material.vertexColors = THREE.VertexColors;
+  tile.material.vertexColors = true;
 
   if (!tile.geometry.attributes.color) {
     //If no vertex color is present, we need to add the BufferAttribute
@@ -424,7 +424,7 @@ export function removeTileVerticesColor(tile) {
   tile.geometry.deleteAttribute('color');
 
   //We go back to the color of the material
-  tile.material.vertexColors = THREE.NoColors;
+  tile.material.vertexColors = false;
 }
 
 /**

--- a/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -172,7 +172,7 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
 
   if (!tile.geometry.attributes.color) {
     //If no vertex color is present, we need to add the BufferAttribute
-    tile.geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3));
+    tile.geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
   } else {
     //Else we need to update the existing attribute
     tile.geometry.attributes.color.set(colors);
@@ -292,13 +292,13 @@ export function createTileGroups(tile, materialsProps, ranges) {
 
 /**
  * Create groups in the tile mesh from the given batch IDs and materials.
- * 
+ *
  * @param {*} tile The 3DTiles tile.
  * @param {Array<any>} groups An array of group descriptors. A group descriptor
  * is a dictionnary containing two entries :
  * - `material` contains the material parameters, such as `color` or `opacity`.
  * - `batchIDs` contains the batch IDs to be applied the given material.
- * 
+ *
  * @example
  * // Fetch the tile
  * let tile = getTileInLayer(layer, 6);
@@ -399,7 +399,7 @@ export function createTileGroupsFromBatchIDs(tile, groups) {
 /**
  * Removes vertex-specific colors of the tile and switch back to the material's
  * color.
- * 
+ *
  * @param {*} tile The 3DTiles tile.
  */
 export function removeTileVerticesColor(tile) {
@@ -421,7 +421,7 @@ export function removeTileVerticesColor(tile) {
   }
 
   //Remove color attribute
-  tile.geometry.removeAttribute('color');
+  tile.geometry.deleteAttribute('color');
 
   //We go back to the color of the material
   tile.material.vertexColors = THREE.NoColors;
@@ -430,7 +430,7 @@ export function removeTileVerticesColor(tile) {
 /**
  * Tells the iTowns view to update the scene. If you made changes to some colors
  * for example, you need to call this function to actually see the changes.
- * 
+ *
  * @param {*} view The iTowns view.
  */
 export function updateITownsView(view, layer) {
@@ -447,11 +447,11 @@ export function updateITownsView(view, layer) {
 
 /**
  * Computes and returns the centroid of the vertices given as parameter.
- * 
+ *
  * @param {*} tile The 3DTiles tile.
  * @param {*} indexArray The indexes of the vertices. It is assumed to be
  * **sorted** and **contiguous**.
- * 
+ *
  * @returns {THREE.Vector3} The centroid of the vertices.
  */
 export function getVerticesCentroid(tile, indexArray) {
@@ -527,13 +527,13 @@ export function getObject3DFromTile(tile) {
  * The TI is an object containing associations between tile, batch IDs and
  * data specific to the batched geometry (vertex indexes, centroid, properties
  * from the batch table).
- * 
+ *
  * @param {*} layer The 3DTiles layer.
  * @param {*} tilesInfo An existing TI for this layer. Tiles that are currently
  * loaded in the layer will be added to the TI if they're not already present.
  * If no TI is provided, a brand new one will be instantiated with currently
  * loaded tiles.
- * 
+ *
  * @example
  * let layer = view.getLayerById(config['3DTilesLayerID']);
  * //Fetch the TI
@@ -547,7 +547,7 @@ export function getObject3DFromTile(tile) {
  * let batchId = getBatchIdFromIntersection(firstInter);
  * //Display the building's infos
  * console.log(tilesInfo.tiles[tileId][batchId]);
- * 
+ *
  * @example
  * let layer = view.getLayerById(config['3DTilesLayerID']);
  * //Initialize the TI

--- a/UD-Viz-Core/src/Utils/3DTiles/Docs/3DTilesUtils.md
+++ b/UD-Viz-Core/src/Utils/3DTiles/Docs/3DTilesUtils.md
@@ -52,7 +52,7 @@ let layer = view.getLayerById(config['3DTilesLayerID']);
 
 The 3DTiles layer has an `object3d` which contains exactly one child of type "Object3D". This child is actually the tileset root, and contains the tiles that are currently displayed in the scene.
 
-The layer also has a `tileIndex` property which describes all tiles. Every tile is listed here, even if they are not rendered in the scene for the moment. However, the THREE.js actual objects representing the tiles are not there.
+The layer also has a `tileset` property which describes all tiles. Every tile is listed here, even if they are not rendered in the scene for the moment. However, the THREE.js actual objects representing the tiles are not there.
 
 ### Batch Table
 

--- a/UD-Viz-Core/src/Utils/3DTiles/TilesManager.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/TilesManager.js
@@ -47,8 +47,8 @@ export class TilesManager {
      */
     this.totalTileCount = 0;
 
-    if (this.layer.tileIndex !== undefined) {
-      this.totalTileCount = Object.keys(this.layer.tileIndex.index).length - 1;
+    if (this.layer.tileset !== undefined) {
+      this.totalTileCount = Object.keys(this.layer.tileset.tiles).length - 1;
     }
 
     ///// STYLE
@@ -77,13 +77,13 @@ export class TilesManager {
    * listeners to events of the 3DTiles layer (tile loading / unloading).
    */
   update() {
-    if (this.layer.tileIndex === undefined) {
+    if (this.layer.tileset === undefined) {
       // Cannot update yet because the layer is not fully loaded.
       return;
     }
 
     if (this.totalTileCount === 0) {
-      this.totalTileCount = Object.keys(this.layer.tileIndex.index).length - 1;
+      this.totalTileCount = Object.keys(this.layer.tileset.tiles).length - 1;
     }
 
     if (this.loadedTileCount === this.totalTileCount) {

--- a/UD-Viz-Core/src/Utils/3DTiles/TilesManager.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/TilesManager.js
@@ -10,7 +10,7 @@ import { StyleManager } from "./StyleManager.js";
 export class TilesManager {
   /**
    * Creates a new TilesManager from an iTowns view and the 3DTiles layer.
-   * 
+   *
    * @param {*} view The iTowns view.
    * @param {*} layer The 3DTiles layer.
    */
@@ -27,7 +27,7 @@ export class TilesManager {
 
     /**
      * The set of tile wrappers that have been loaded.
-     * 
+     *
      * @type {Array<Tile>}
      */
     this.tiles = [];
@@ -35,14 +35,14 @@ export class TilesManager {
     /**
      * The number of tiles currently loaded by the tile manager. If this number
      * is equal to `totalTileCount`, no more `update` is necessary.
-     * 
+     *
      * @type {number}
      */
     this.loadedTileCount = 0;
 
     /**
      * The total number of tiles in the scene.
-     * 
+     *
      * @type {number}
      */
     this.totalTileCount = 0;
@@ -56,7 +56,7 @@ export class TilesManager {
 
     /**
      * Manages the styles of the city objects.
-     * 
+     *
      * @type {StyleManager}
      */
     this.styleManager = new StyleManager();
@@ -64,7 +64,7 @@ export class TilesManager {
     /**
      * Keep tracks of the update of tiles. Associate each tile with the UUID of
      * their Object3D during the last update.
-     * 
+     *
      * @type {Object.<number, string>}
      */
     this.upToDateTileIds = {};
@@ -105,9 +105,9 @@ export class TilesManager {
 
   /**
    * Returns the city object, if the tile is loaded.
-   * 
+   *
    * @param {CityObjectID} cityObjectId The city object identifier.
-   * 
+   *
    * @return {CityObject}
    */
   getCityObject(cityObjectId) {
@@ -126,10 +126,10 @@ export class TilesManager {
   /**
    * Search and returns the first city object that matches the given predicate.
    * If no city object matches the predicate, `undefined` is returned.
-   * 
+   *
    * @param {(cityObject: CityObject) => boolean} predicate The predicate to
    * determine the city object.
-   * 
+   *
    * @returns {CityObject | undefined} The first city object that matches the
    * predicate, or `undefined` if no city object is found.
    */
@@ -146,10 +146,10 @@ export class TilesManager {
 
   /**
    * Search and returns all city objects that matches the given predicate.
-   * 
+   *
    * @param {(cityObject: CityObject) => boolean} predicate The predicate to
    * determine the city objects.
-   * 
+   *
    * @returns {Array<CityObject>} An array of all the city object that matches
    * the predicate.
    */
@@ -167,7 +167,7 @@ export class TilesManager {
 
   /**
    * Sets the style of a particular city object.
-   * 
+   *
    * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
    * identifier.
    * @param {CityObjectStyle | string} style The desired style.
@@ -195,7 +195,7 @@ export class TilesManager {
 
   /**
    * Register a new or modify an existing registered style.
-   * 
+   *
    * @param {string} name A name to identify the style.
    * @param {CityObjectStyle} style The style to register.
    */
@@ -214,7 +214,7 @@ export class TilesManager {
 
   /**
    * Removes the style of a particular city object.
-   * 
+   *
    * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
    * identifier.
    */
@@ -243,7 +243,7 @@ export class TilesManager {
 
   /**
    * Removes all styles for the given tile.
-   * 
+   *
    * @param {number} tileId The tile ID.
    */
   removeStyleFromTile(tileId) {
@@ -264,9 +264,9 @@ export class TilesManager {
 
   /**
    * Gets the style applied to a given object ID.
-   * 
+   *
    * @param {CityObjectID} cityObjectId The city object ID.
-   * 
+   *
    * @returns {CityObjectStyle}
    */
   getStyleAppliedTo(cityObjectId) {
@@ -278,7 +278,7 @@ export class TilesManager {
 
   /**
    * Applies the current styles added with `setStyle` or `addStyle`.
-   * 
+   *
    * @param {object} options Options of the method.
    * @param {() => any} [options.updateFunction] The function used to update the
    * view. Default is `udpateITownsView(view, layer)`.
@@ -301,7 +301,7 @@ export class TilesManager {
 
   /**
    * Apply the saved style to the tile given in parameter.
-   * 
+   *
    * @param {number} tileId The ID of the tile to apply the style to.
    * @param {object} options Options of the apply function.
    * @param {boolean} [options.updateView] Whether the view should update at the
@@ -330,9 +330,9 @@ export class TilesManager {
   /**
    * Sets the saved UUID of the tile, so that it should be updated in the next
    * `applyStyles` call.
-   * 
+   *
    * @private
-   * 
+   *
    * @param {number} tileId The ID of the tile to update.
    */
   _markTileToUpdate(tileId) {
@@ -341,9 +341,9 @@ export class TilesManager {
 
   /**
    * Updates the saved UUID of the tile.
-   * 
+   *
    * @private
-   * 
+   *
    * @param {Tile} tile The tile to mark.
    */
   _markTileAsUpdated(tile) {
@@ -358,9 +358,9 @@ export class TilesManager {
 
   /**
    * Checks if the style of the tile should be updated.
-   * 
+   *
    * @private
-   * 
+   *
    * @param {Tile} tile The tile.
    */
   _shouldTileBeUpdated(tile) {

--- a/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -235,7 +235,7 @@ export class BaseDemo {
         let moduleClass = this.getModuleById(moduleId);
 
         //dynamically color the button
-        moduleClass.parentElement = this.viewerDivElement;
+        moduleClass.parentElement = this.viewerDivElement.parentElement;
         moduleClass.addEventListener(ModuleView.EVENT_ENABLED, () => {
             button.className = 'choiceMenu choiceMenuSelected';
 
@@ -256,7 +256,7 @@ export class BaseDemo {
         frame.innerHTML = this.authenticationFrameHtml;
         this.authFrameLocationElement.appendChild(frame);
         const authView = this.getModuleById(authModuleId);
-        authView.parentElement = this.viewerDivElement;
+        authView.parentElement = this.viewerDivElement.parentElement;
         const authService = authView.authenticationService;
         this.authenticationLoginButtonElement.onclick = () => {
             if (this.isModuleActive(authModuleId)) {
@@ -408,26 +408,27 @@ export class BaseDemo {
                 "(in UD-Viz/UD-Viz-Core/examples/data/config/generalDemoConfig.json)";
         }
 
-        let $3dTilesLayer = new itowns.GeometryLayer(
-            this.config['3DTilesLayer'][layerConfig]['id'], new THREE.Group(), {transparent: true});
-        $3dTilesLayer.name = 'Lyon-2015-'.concat(layerConfig);
-        $3dTilesLayer.url =
-            this.config['3DTilesLayer'][layerConfig]['url'];
-        $3dTilesLayer.protocol = '3d-tiles';
+        var $3dTilesLayer = new itowns.C3DTilesLayer(
+            this.config['3DTilesLayer'][layerConfig]['id'], {
+                name: 'Lyon-2015-'.concat(layerConfig),
+                url: this.config['3DTilesLayer'][layerConfig]['url'],
+            }, this.view);
 
         let material;
-        if (this.config['3DTilesLayer'][layerConfig]['pc_size']) 
+        if (this.config['3DTilesLayer'][layerConfig]['pc_size'])
         {
             material = new THREE.PointsMaterial({ size: this.config['3DTilesLayer'][layerConfig]['pc_size'], vertexColors: THREE.VertexColors });
         }
-        else if (this.config['3DTilesLayer'][layerConfig]['color']) 
-        {
-            material = new THREE.MeshLambertMaterial({ color: parseInt(this.config['3DTilesLayer'][layerConfig]['color']), opacity: 0.5, transparent: true });
+        else if (!this.config['3DTilesLayer'][layerConfig]['color']) {
+            material = new THREE.MeshLambertMaterial({ color: 0xFFFFFF });
+        } else {
+            material =
+                new THREE.MeshLambertMaterial({color: parseInt(this.config['3DTilesLayer'][layerConfig]['color'])});
         }
 
         $3dTilesLayer.overrideMaterials = material;
         $3dTilesLayer.material = material;
-        
+
         itowns.View.prototype.addLayer.call(this.view, $3dTilesLayer);
 
 
@@ -458,12 +459,31 @@ export class BaseDemo {
             'EPSG:3946',
             min_x, max_x,
             min_y, max_y);
+
+        // Get camera placement parameters from config
+        let coordinates = this.extent.center();
+        if (this.config['camera'][area]['position']['x']
+            && this.config['camera'][area]['position']['y']) {
+            coordinates = new itowns.Coordinates('EPSG:3946',
+                parseInt(this.config['camera'][area]['position']['x']),
+                parseInt(this.config['camera'][area]['position']['y']));
+        }
+        let heading = parseFloat(this.config['camera'][area]['position']['heading']);
+        let range = parseFloat(this.config['camera'][area]['position']['range']);
+        let tilt = parseFloat(this.config['camera'][area]['position']['tilt']);
+
         // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
         let viewerDiv = document.getElementById('viewerDiv');
         // Instantiate PlanarView (iTowns' view that will hold the layers)
         // The skirt allows to remove the cracks between the terrain tiles
         this.view = new itowns.PlanarView(viewerDiv, this.extent, {
-            disableSkirt: false
+            disableSkirt: false,
+            placement: {
+                coord: coordinates,
+                heading: heading,
+                range: range,
+                tilt: tilt
+            }
         });
         this.layerManager = new LayerManager(this.view);
         // ********* 3D Elements
@@ -477,25 +497,6 @@ export class BaseDemo {
         ambientLight.position.set(0, 0, 3000);
         directionalLight.updateMatrixWorld();
         this.view.scene.add(ambientLight);
-        // Camera
-
-        let coordinates = this.extent.center();
-        let range = parseFloat(this.config['camera'][area]['position']['range']);
-        let tilt = parseFloat(this.config['camera'][area]['position']['tilt']);
-        let heading = parseFloat(this.config['camera'][area]['position']['heading']);
-
-        if (this.config['camera'][area]['position']['x']
-          && this.config['camera'][area]['position']['y']) {
-          coordinates = new itowns.Coordinates('EPSG:3946',
-            parseInt(this.config['camera'][area]['position']['x']),
-            parseInt(this.config['camera'][area]['position']['y']));
-        }
-
-        let p = {
-            coord: coordinates, heading: heading, range: range, tilt: tilt
-          };
-
-        itowns.CameraUtils.transformCameraToLookAtTarget(this.view, this.view.camera.camera3D, p);
 
         // Controls
         this.controls = new itowns.PlanarControls(this.view, { maxZenithAngle: 180, groundLevel: -100, handleCollision: false });
@@ -531,8 +532,6 @@ export class BaseDemo {
             }
         });
     }
-
-
 
     ////////////////////////////////////////////////////////
     // GETTERS FOR HTML IDS AND ELEMENTS OF THE DEMO PAGE //

--- a/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -411,7 +411,9 @@ export class BaseDemo {
         var $3dTilesLayer = new itowns.C3DTilesLayer(
             this.config['3DTilesLayer'][layerConfig]['id'], {
                 name: 'Lyon-2015-'.concat(layerConfig),
-                url: this.config['3DTilesLayer'][layerConfig]['url'],
+                source: new itowns.C3DTilesSource({
+                    url: this.config['3DTilesLayer'][layerConfig]['url'],
+                }),
             }, this.view);
 
         let material;

--- a/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UD-Viz-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -417,7 +417,7 @@ export class BaseDemo {
         let material;
         if (this.config['3DTilesLayer'][layerConfig]['pc_size'])
         {
-            material = new THREE.PointsMaterial({ size: this.config['3DTilesLayer'][layerConfig]['pc_size'], vertexColors: THREE.VertexColors });
+            material = new THREE.PointsMaterial({ size: this.config['3DTilesLayer'][layerConfig]['pc_size'], vertexColors: true });
         }
         else if (!this.config['3DTilesLayer'][layerConfig]['color']) {
             material = new THREE.MeshLambertMaterial({ color: 0xFFFFFF });


### PR DESCRIPTION
This PR updates the following packages: 

* itowns: 2.15.3 -> 2.23.0
* threejs: 0.109.0 -> 0.117.1
* proj4: 2.5.0 -> 2.6.2

This update highlighted that there was a mistake in the gltf part of all of our 3D Tiles datasets. It has been corrected server side (on the tiler branch of our [py3dtiles' fork](https://github.com/VCityTeam/py3dtiles/pull/3) and on [Oslandia's gitlab](https://gitlab.com/Oslandia/py3dtiles/-/merge_requests/83)). However, we must re-compute [all the 3D Tiles datasets used in our demo](https://github.com/VCityTeam/UD-Viz/blob/master/UD-Viz-Core/examples/data/config/generalDemoConfig.json#L114) with the fixed py3dtiles version.

You will find below a list of the 3D Tiles datasets that we use along with a proposition of the strategy to re-compute them and assignees to this job (feel free to edit this strategy/the assignees). Computing all the datasets may not be possible right now since it depends on existing and new pipelines that are ongoing work. This PR is "critical" for other work (e.g. merging [the UD-Viz temporal branch](https://github.com/VCityTeam/UD-Viz/tree/UDV-temporal)). Therefore, I propose to merge it and temporally accept that only the demo using the `building` dataset (computed manually, see below) works on the master until we re-compute the other ones with the pipelines. @ggesquiere and @EricBoix what's your opinion on this ?

The list of 3D Tiles datasets used in our demos:

````
    "building":{
      "id":"3d-tiles-layer-building",
      "url":"http://rict2.liris.cnrs.fr/DataStore/Lyon-2015-gltf-repaired/tileset.json",
      "color": "0xFFFFFF",
      "initTilesManager": "true"
    },
````
--> Computed by running py3dtiles manually (for test purposes); could be computed again with the static tiler pipeline. Assignees: EBO/VJA 

````
    "limonest_building":{
      "id":"3d-tiles-layer-building",
      "url":"http://rict2.liris.cnrs.fr/DataStore/limonest_tiles/tileset.json",
      "color": "0xFFFFFF",
      "initTilesManager": "true"
    },
````
--> Must be computed with the static tiler pipeline. Assignees: EBO/VJA 

````
    "bron_building":{
      "id":"3d-tiles-layer-building",
      "url":"http://rict2.liris.cnrs.fr/DataStore/bron_tiles/tileset.json",
      "color": "0xFFFFFF",
      "initTilesManager": "true"
    },
````
--> Must be computed with the static tiler pipeline. Assignees: EBO/VJA 

````
    "point_clouds":{
      "id":"3d-tiles-layer-point-clouds",
      "url":"http://rict2.liris.cnrs.fr/DataStore/point_clouds_tiles/tileset.json",
      "color": "0xFFFFFF",
      "pc_size":2,
      "initTilesManager": "true"
    },
````
--> Must be computed with a new pipeline for pointclouds. Assignees: CCO 

````
    "building_1_2_5":{
      "id":"3d-tiles-layer-building_1_2_5",
      "url":"http://rict.liris.cnrs.fr/DataStore/TileSets_Demo_MultiLayerLyon1_Lyon2_Lyon5_2015/tileset_buildings/tileset.json",
      "color": "0xFFFFFF",
      "initTilesManager": "true"
    },
````

--> Must be computed with the static tiler pipeline. Assignees: EBO/VJA 

````
    "relief":{
      "id":"3d-tiles-layer-relief",
      "url":"http://rict.liris.cnrs.fr/DataStore/TileSets_Demo_MultiLayerLyon1_Lyon2_Lyon5_2015/tileset_reliefs/tileset.json",
      "color": "0xD2B48C"
    },
````

--> Must be computed with the static tiler pipeline + with special parameters for relief ? Assignees: EBO 

````
    "water":{
      "id":"3d-tiles-layer-water",
      "url":"http://rict.liris.cnrs.fr/DataStore/TileSets_Demo_MultiLayerLyon1_Lyon2_Lyon5_2015/tileset_water_bodies/tileset.json",
      "color": "0xB0E0E6"
    }
  },
````

--> Must be computed with the static tiler pipeline + with special parameters for relief ? Assignees: EBO