### PR TITLE
Event-based 3D Tiles information update

### DIFF
--- a/UD-Viz-Core/src/Modules/CityObjects/View/CityObjectFilterSelector.js
+++ b/UD-Viz-Core/src/Modules/CityObjects/View/CityObjectFilterSelector.js
@@ -1,5 +1,3 @@
-import { EventSender } from "../../../Utils/Events/EventSender";
-
 /**
  * Represents an option in the list of filters the user can select. It also
  * stores additional HTML that can be put in a form if the filter accepts

--- a/UD-Viz-Core/src/Modules/CityObjects/ViewModel/CityObjectProvider.js
+++ b/UD-Viz-Core/src/Modules/CityObjects/ViewModel/CityObjectProvider.js
@@ -191,7 +191,6 @@ export class CityObjectProvider extends EventSender {
    * @private
    */
   _updateTilesManager() {
-    this.layerManager.update3DTiles();
     this.layerManager.removeAll3DTilesStyles();
     if (!!this.selectedCityObject) {
       let tileManager = this.layerManager.getTilesManagerByLayerID(this.selectedCityObject.tile.layer.id);

--- a/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UD-Viz-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -565,8 +565,7 @@ export function getTilesInfo(layer, tilesInfo = null) {
     tilesInfo.tileset;
   }
   let tileset = layer.tileset;
-  let tileCount = Object.keys(tileset.tiles).length - 1; // -1 because of the
-                                                           // root tile
+  let tileCount = tileset.tiles.length;
   tilesInfo.totalTileCount = tileCount;
   let rootTile = layer.object3d.children[0];
   tilesInfo.tileset = rootTile;

--- a/UD-Viz-Core/src/Utils/Events/EventSender.js
+++ b/UD-Viz-Core/src/Utils/Events/EventSender.js
@@ -21,7 +21,7 @@ export class EventSender {
     }
 
     /**
-     * Registers an event. Should be clalled by the implementing class to
+     * Registers an event. Should be called by the implementing class to
      * specify its own events.
      * @param event The event to register. Can be of any type. The class will be
      *              able to send only the events that it has registered.

--- a/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
+++ b/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
@@ -1,5 +1,4 @@
-import { TilesManager } from "../3DTiles/TilesManager.js";
-import { getVisibleTiles, updateITownsView, getFirstTileIntersection, getBatchIdFromIntersection, getObject3DFromTile, getVisibleTileCount } from "../3DTiles/3DTilesUtils.js";
+import { getFirstTileIntersection, getBatchIdFromIntersection, getObject3DFromTile, getVisibleTileCount } from "../3DTiles/3DTilesUtils.js";
 
 
 export class LayerManager {
@@ -21,18 +20,6 @@ export class LayerManager {
          */
         this.tilesManagers = [];
     }
-
-
-
-    /**
-    * Update all 3DTiles and constructs the tiles that have not been loaded yet. 
-    */
-    update3DTiles() {
-        this.tilesManagers.forEach(function(tilesManager){
-            tilesManager.update();
-        });
-    }
-
 
     /**
      * Register a new or modify an existing registered style for all tilesManager.
@@ -92,8 +79,6 @@ export class LayerManager {
         });
     }
 
-
-
     /**
     * Update the scale of the given layer
     * @param {itowns.Layer} layer one layer loaded.
@@ -131,7 +116,6 @@ export class LayerManager {
      */
     pickCityObject(event) {
         if (event.target.nodeName.toUpperCase() === 'CANVAS') {
-            this.update3DTiles();
             // Get the intersecting objects where our mouse pointer is
             let intersections = [];
             //As the current pickObjectsAt on all layer is not working, we need 


### PR DESCRIPTION
Use iTowns recently added `onTileContentLoaded` event to trigger 3D Tiles related model and view updates in UD-Viz instead of requesting an update of the 3D Tiles layer to iTowns every time we need to use it.