### PR TITLE
Update iTowns to 2.25.0

### DIFF
--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.24.2",
+    "itowns": "2.25.0",
     "moment": "^2.19.0",
     "proj4": "^2.6.2",
     "three": "^0.117.1"

--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "es6-promise": "^4.0.5",
-    "itowns": "2.23.0",
+    "itowns": "2.24.2",
     "moment": "^2.19.0",
     "proj4": "^2.6.2",
     "three": "^0.117.1"

--- a/UD-Viz-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UD-Viz-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -18,14 +18,14 @@ export class Debug3DTilesWindow extends Window {
      * @type {layerManager}
      */
     this.layerManager = layerManager;
-
     // Selection
     this.layerManager.registerStyle('selected', new CityObjectStyle({
       materialProps: { color: 0x00ff00 }
     }));
     this.selectedCityObject = undefined;
     this.selectedTilesManager = undefined;
-
+    
+    let viewerDiv = document.getElementById('viewerDiv');
     let clickListener = (event) => {
       this.onMouseClick(event);
     };
@@ -33,12 +33,12 @@ export class Debug3DTilesWindow extends Window {
       this.onMouseMove(event);
     };
     this.addEventListener(Window.EVENT_ENABLED, () => {
-      window.addEventListener('mousedown', clickListener);
-      window.addEventListener('mousemove', moveListener);
+      viewerDiv.addEventListener('mousedown', clickListener);
+      viewerDiv.addEventListener('mousemove', moveListener);
     });
     this.addEventListener(Window.EVENT_DISABLED, () => {
-      window.removeEventListener('mousedown', clickListener);
-      window.removeEventListener('mousemove', moveListener);
+      viewerDiv.removeEventListener('mousedown', clickListener);
+      viewerDiv.removeEventListener('mousemove', moveListener);
 
       if (this.selectedCityObject !== undefined) {
         this.selectedCityObject = undefined;

--- a/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingStyle.css
+++ b/UD-Viz-Core/src/Extensions/Geocoding/views/GeocodingStyle.css
@@ -1,5 +1,6 @@
 #_geocoding_view {
   position: absolute;
+  z-index: 200;
   top: 30px;
   width: 100%;
 }

--- a/UD-Viz-Core/src/Modules/CityObjects/View/CityObjectWindow.js
+++ b/UD-Viz-Core/src/Modules/CityObjects/View/CityObjectWindow.js
@@ -57,6 +57,7 @@ export class CityObjectWindow extends Window {
      */
     this.extensions = [];
 
+    let viewerDiv = document.getElementById('viewerDiv');
     /**
      * The event listener for mouse clicks.
      * 
@@ -67,12 +68,12 @@ export class CityObjectWindow extends Window {
       this.provider.applyStyles();
     };
     this.addEventListener(Window.EVENT_ENABLED, () => {
-      window.addEventListener('mousedown', this.mouseClickListener);
+      viewerDiv.addEventListener('mousedown', this.mouseClickListener);
     });
     this.addEventListener(Window.EVENT_DISABLED, () => {
       this.provider.removeLayer();
       this.provider.unselectCityObject();
-      window.removeEventListener('mousedown', this.mouseClickListener);
+      viewerDiv.removeEventListener('mousedown', this.mouseClickListener);
     });
 
 

--- a/UD-Viz-Core/src/Modules/Others/About.css
+++ b/UD-Viz-Core/src/Modules/Others/About.css
@@ -1,6 +1,7 @@
 
 #aboutWindow {
     position: absolute;
+    z-index: 11;
     top: 10px;
     width: 15%;
     right : 22.5%;

--- a/UD-Viz-Core/src/Modules/Others/Help.css
+++ b/UD-Viz-Core/src/Modules/Others/Help.css
@@ -1,5 +1,6 @@
 #helpWindow {
     position: absolute;
+    z-index: 10;
     width: 15%;
     top: 10px;
     left : 22.5%;

--- a/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
+++ b/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
@@ -115,7 +115,11 @@ export class LayerManager {
      * @returns {CityObject | undefined}
      */
     pickCityObject(event) {
-        // Make sure the event is captured by a click listener attached to the div#viewerDiv, which contains the iTowns canvas
+        /**
+        * Make sure the event is captured by a click listener attached 
+        * to the div#viewerDiv, which contains the iTowns canvas. All click 
+        * listeners should be instantiated this way as of iTowns 2.24.0
+        */
         if (event.currentTarget.id.toUpperCase() === 'VIEWERDIV') {
             // Get the intersecting objects where our mouse pointer is
             let intersections = [];

--- a/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
+++ b/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
@@ -115,7 +115,7 @@ export class LayerManager {
      * @returns {CityObject | undefined}
      */
     pickCityObject(event) {
-        if (event.target.nodeName.toUpperCase() === 'CANVAS') {
+        if (event.currentTarget.id.toUpperCase() === 'VIEWERDIV') {
             // Get the intersecting objects where our mouse pointer is
             let intersections = [];
             //As the current pickObjectsAt on all layer is not working, we need 

--- a/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
+++ b/UD-Viz-Core/src/Utils/LayerManager/LayerManager.js
@@ -115,6 +115,7 @@ export class LayerManager {
      * @returns {CityObject | undefined}
      */
     pickCityObject(event) {
+        // Make sure the event is captured by a click listener attached to the div#viewerDiv, which contains the iTowns canvas
         if (event.currentTarget.id.toUpperCase() === 'VIEWERDIV') {
             // Get the intersecting objects where our mouse pointer is
             let intersections = [];


### PR DESCRIPTION
fix a bug caused by a new **div#viewerDiv > div** which obstructs the about and help menus and blocks click events from propagating to the iTowns canvas
- about and help menus now declare a z-index in their CSS files above the new div
- CityObjects and 3DTilesDebug modules/extensions now create their click listeners directly on the div#viewerDiv instead of the window
- the layerManager.pickCityObject function now looks for the event currentTarget ID to make sure the click listener is attached to the #viewerDiv instead of returning the target nodeName.
  - if a click listener is created - which needs layerManager.pickCityObject - but is not attached to the div#viewerDiv, layerManager.pickCityObject will return undefined 