### PR TITLE
Brutal tentative to fix lagging package.json

### DIFF
--- a/UD-Viz-Core/package.json
+++ b/UD-Viz-Core/package.json
@@ -40,16 +40,15 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-minify-dead-code-elimination": "^0.2.0",
     "babel-plugin-transform-runtime": "^6.22.0",
-    "babel-plugin-webpack-loaders": "^0.9.0",
     "babel-preset-env": "^1.6.0",
     "chart.js": "^2.4.0",
     "cross-env": "^3.1.4",
     "css-loader": "^3.2.0",
-    "eslint": "^3.14.0",
-    "eslint-config-airbnb-base": "^11.3.0",
-    "eslint-import-resolver-webpack": "^0.8.1",
-    "eslint-loader": "^1.7.1",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint": "^7.10.0",
+    "eslint-config-airbnb-base": "^14.2.0",
+    "eslint-import-resolver-webpack": "^0.13.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-webpack-plugin": "",
     "file-loader": "^1.1.11",
     "imports-loader": "^0.7.1",
     "jsdoc": "^3.4.3",
@@ -59,7 +58,7 @@
     "require-from-string": "^1.2.1",
     "style-loader": "^0.20.3",
     "url-loader": "^1.0.1",
-    "webpack": "^3.0.0",
-    "webpack-dev-server": "^2.4.5"
+    "webpack": "^4.0.0",
+    "webpack-dev-server": "^3.0.0"
   }
 }


### PR DESCRIPTION
The error message on "npm install" went
   webpack@“^3.0.0” from the root project
   Could not resolve dependency:
   peer webpack@“>=1.12.9 <3.0.0" from babel-plugin-webpack-loaders@0.9.0

npm complains about eslint tentatively fixed by aligning
package version with iTowns choices.