### PR TITLE
Change billboard mask material

### DIFF
--- a/src/Widgets/Billboard/Billboard.js
+++ b/src/Widgets/Billboard/Billboard.js
@@ -1,11 +1,13 @@
 import * as THREE from 'three';
 import THREEUtils from '../../Game/Shared/Components/THREEUtils';
 import { CSS3DObject } from 'three/examples/jsm/renderers/CSS3DRenderer';
+import { Color } from 'three';
 
 const BLANK_MATERIAL = new THREE.MeshBasicMaterial({
   side: THREE.DoubleSide,
   opacity: 0,
   blending: THREE.NoBlending,
+  color : new Color(0,0,0),
 });
 
 export class Billboard {


### PR DESCRIPTION
Billboard was blank when we create it due to the material of the mask in the webgl renderer even if the opacity is equal to 0.
To fix this we have change the color to black.