### PR TITLE
properly sending event when tile is loaded

### DIFF
--- a/src/Components/3DTiles/TilesManager.js
+++ b/src/Components/3DTiles/TilesManager.js
@@ -133,6 +133,7 @@ export class TilesManager extends EventSender {
     //  pourra etre dans le if ci dessus
     this.setDefaultStyle();
     this.applyStyles();
+    this.sendEvent(TilesManager.EVENT_TILE_LOADED, tile);
   }
 
   getTilesWithGeom() {


### PR DESCRIPTION
During the transition between v2.33.8 and v2.34.0, this [line](https://github.com/VCityTeam/UD-Viz/compare/v2.33.8...v2.34.0#diff-bca66714184d12548990025a4e2f64dd50cdd4d76d3d1f8e80ae6d170bf54493L111) that triggered an event when a tile is loaded was deleted.

This PR fix this mistake and fix adhoc bug (3dtiles debug widget not actualizing for example)