### PR TITLE
Fix tile selection with CityObject and 3DTilesDebug widgets

### DIFF
--- a/src/Components/3DTiles/3DTilesUtils.js
+++ b/src/Components/3DTiles/3DTilesUtils.js
@@ -39,24 +39,13 @@ export function getBatchIdFromIntersection(inter) {
  * itowns.View.pickObjectsAt
  */
 export function getFirstTileIntersection(intersects) {
-  let first_inter = null;
-  let dist_min = 0;
   for (let inter of intersects) {
-
-    if(inter.object.visible){
-      let geomAttributes = inter.object.geometry.attributes;
-      if (geomAttributes && geomAttributes._BATCHID) {
-        if (!first_inter) {
-          first_inter = inter;
-          dist_min = inter.distance;
-        } else if (inter.distance < dist_min) {
-          first_inter = inter;
-          dist_min = inter.distance;
-        }
-      }
+    let tile = getTileFromMesh(inter.object);
+    if(inter.object.visible && tile.visible && tile.content.visible){
+      return inter;
     }
   }
-  return first_inter;
+  return null;
 }
 
 /**
@@ -554,21 +543,21 @@ export function getMeshesFromTile(tile) {
   return tile.children;
 }
 
-export function getObject3DFromTile(tile) {
-  if (!tile) {
-    throw 'Tile not loaded in view';
+export function getTileFromMesh(object) {
+  if (!object) {
+    throw 'Object not loaded in view';
   }
 
   //Find the 'Object3D' part of the tile
-  while (!!tile.parent && !(tile.type === 'Object3D')) {
-    tile = tile.parent;
+  while (!!object.parent && !(object.type === 'Object3D')) {
+    object = object.parent;
   }
 
-  if (!tile.batchTable) {
+  if (!object.batchTable) {
     throw 'Invalid tile : no batch table';
   }
 
-  return tile;
+  return object;
 }
 
 /**

--- a/src/Components/LayerManager/LayerManager.js
+++ b/src/Components/LayerManager/LayerManager.js
@@ -3,7 +3,7 @@
 import {
   getFirstTileIntersection,
   getBatchIdFromIntersection,
-  getObject3DFromTile,
+  getTileFromMesh,
   getVisibleTileCount,
 } from '../3DTiles/3DTilesUtils';
 
@@ -153,7 +153,7 @@ export class LayerManager {
       if (firstInter) {
         let tilesManager = this.getTilesManagerByLayerID(firstInter.layer.id);
         let batchId = getBatchIdFromIntersection(firstInter);
-        let tileId = getObject3DFromTile(firstInter.object).tileId;
+        let tileId = getTileFromMesh(firstInter.object).tileId;
         return tilesManager.tiles[tileId].cityObjects[batchId];
       }
     }


### PR DESCRIPTION
- Can't select invisible tiles anymore.
- Rename the method `getObject3DFromTile` to `getMeshFromTile`, since this method actually finds the Tile from a Mesh
