### PR TITLE
Use 'crs' instead of deprecated 'projection' in layers

### DIFF
--- a/src/Components/ItownsViewUtils.js
+++ b/src/Components/ItownsViewUtils.js
@@ -189,7 +189,7 @@ export function addBaseMapLayer(config, itownsView, extent) {
     name: config['background_image_layer']['name'],
     url: config['background_image_layer']['url'],
     version: config['background_image_layer']['version'],
-    projection: config['projection'],
+    crs: config['projection'],
     format: config['background_image_layer']['format'],
   });
   // Add a WMS imagery layer
@@ -261,7 +261,7 @@ export function addElevationLayer(config, itownsView, extent) {
     extent: extent,
     url: config['elevation_layer']['url'],
     name: config['elevation_layer']['name'],
-    projection: config['projection'],
+    crs: config['projection'],
     heightMapWidth: 256,
     format: config['elevation_layer']['format'],
   });

--- a/src/Widgets/BaseMap/BaseMapWindow.js
+++ b/src/Widgets/BaseMap/BaseMapWindow.js
@@ -47,7 +47,7 @@ export class BaseMap extends Window {
         name: layer.name,
         url: layer.url,
         version: layer.version,
-        projection: this.appProjection,
+        crs: this.appProjection,
         format: 'image/jpeg',
       });
       // Add a WMS imagery layer


### PR DESCRIPTION
Fix the following warning: 

![image](https://user-images.githubusercontent.com/32875283/204007131-dfd29621-4e24-4b73-8d38-a020cee14982.png)
