### PR TITLE
Base map subdivision

### DIFF
--- a/examples/assets/config/all_widget_config.json
+++ b/examples/assets/config/all_widget_config.json
@@ -44,14 +44,14 @@
     "timeStep": 1
   },
   "projection": "EPSG:3946",
+  "maxSubdivisionLevel": 10,
   "background_image_layer": {
     "url": "https://download.data.grandlyon.com/wms/grandlyon",
     "name": "Ortho2018_Dalle_unique_8cm_CC46",
     "version": "1.3.0",
     "format": "image/jpeg",
     "layer_name": "Base_Map",
-    "transparent": true,
-    "maxSubdivisionLevel": 3
+    "transparent": true
   },
   "elevation_layer": {
     "url": "https://download.data.grandlyon.com/wms/grandlyon",

--- a/examples/assets/config/baseMap_config.json
+++ b/examples/assets/config/baseMap_config.json
@@ -17,6 +17,7 @@
     ]
   },
   "projection": "EPSG:3946",
+  "maxSubdivisionLevel": 10,
   "baseMapLayers": [
     {
       "url": "https://download.data.grandlyon.com/wms/grandlyon",

--- a/examples/assets/config/geojson_config.json
+++ b/examples/assets/config/geojson_config.json
@@ -37,14 +37,14 @@
     }
   },
   "projection": "EPSG:3946",
+  "maxSubdivisionLevel": 10,
   "background_image_layer": {
     "url": "https://download.data.grandlyon.com/wms/grandlyon",
     "name": "Ortho2018_Dalle_unique_8cm_CC46",
     "version": "1.3.0",
     "format": "image/jpeg",
     "layer_name": "Base_Map",
-    "transparent": true,
-    "maxSubdivisionLevel": 3
+    "transparent": true
   },
   "elevation_layer": {
     "url": "https://download.data.grandlyon.com/wms/grandlyon",

--- a/examples/assets/config/worldMap_config.json
+++ b/examples/assets/config/worldMap_config.json
@@ -24,13 +24,13 @@
     }
   },
   "projection": "EPSG:3857",
+  "maxSubdivisionLevel": 18,
   "background_image_layer": {
     "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/r/wms",
     "name": "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
     "version": "1.3.0",
     "format": "image/jpeg",
-    "layer_name": "Base_Map",
-    "maxSubdivisionLevel": 18
+    "layer_name": "Base_Map"
   },
   "camera": {
     "position": {

--- a/src/Views/View3D/View3D.js
+++ b/src/Views/View3D/View3D.js
@@ -378,7 +378,7 @@ export class View3D {
     };
 
     // MaxSubdivisionLevel
-    let maxSubdivisionLevel = 3;
+    let maxSubdivisionLevel = this.config.maxSubdivisionLevel || 3;
     if (this.config.background_image_layer)
       if (this.config.background_image_layer.maxSubdivisionLevel)
         maxSubdivisionLevel =

--- a/src/Views/View3D/View3D.js
+++ b/src/Views/View3D/View3D.js
@@ -378,7 +378,7 @@ export class View3D {
     };
 
     // MaxSubdivisionLevel
-    let maxSubdivisionLevel = this.config.maxSubdivisionLevel || 3;
+    const maxSubdivisionLevel = this.config.maxSubdivisionLevel || 3;
 
     this.itownsView = new itowns.PlanarView(this.rootWebGL, extent, {
       disableSkirt: false,

--- a/src/Views/View3D/View3D.js
+++ b/src/Views/View3D/View3D.js
@@ -379,10 +379,6 @@ export class View3D {
 
     // MaxSubdivisionLevel
     let maxSubdivisionLevel = this.config.maxSubdivisionLevel || 3;
-    if (this.config.background_image_layer)
-      if (this.config.background_image_layer.maxSubdivisionLevel)
-        maxSubdivisionLevel =
-          this.config.background_image_layer.maxSubdivisionLevel;
 
     this.itownsView = new itowns.PlanarView(this.rootWebGL, extent, {
       disableSkirt: false,


### PR DESCRIPTION
`baseMapSubdivisionLevel ` can be used in config without a `background_image_layer`. This allow to use the maxSubdivisionLevel with the BaseMap widget