### PR TITLE
Change ColorLayers sequence order in BaseMap widget

### DIFF
--- a/src/Widgets/BaseMap/BaseMapWindow.js
+++ b/src/Widgets/BaseMap/BaseMapWindow.js
@@ -61,6 +61,7 @@ export class BaseMap extends Window {
       });
       if (i != 0) colorLayer.visible = false;
       this.itownsView.addLayer(colorLayer);
+      itowns.ColorLayersOrdering.moveLayerToIndex(this.itownsView, layer.id, i);
       i++;
     }
   }


### PR DESCRIPTION
Move the ColorLayers created by the BaseMap Widget on the top of the sequence order. It ensures that those layers are rendered before the GeoJSONLayers 