### PR TITLE
Compute near far camera height #469

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7708,9 +7708,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -13838,9 +13838,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/packages/browser/src/Component/Frame3D/Frame3DPlanar.js
+++ b/packages/browser/src/Component/Frame3D/Frame3DPlanar.js
@@ -77,11 +77,8 @@ export class Frame3DPlanar extends Frame3DBase {
       this.itownsView.addFrameRequester(
         itowns.MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE,
         () => {
-          // z is HARDCODED https://github.com/VCityTeam/UD-Viz/issues/469
-          const min = new THREE.Vector3(extent.west, extent.south, 0);
-          const max = new THREE.Vector3(extent.east, extent.north, 1000);
-
-          computeNearFarCamera(this.camera, min, max);
+          const bb = new THREE.Box3().setFromObject(this.scene);
+          computeNearFarCamera(this.camera, bb.min, bb.max);
         }
       );
 


### PR DESCRIPTION
Should wait merge of this branch https://github.com/VCityTeam/UD-Viz/tree/488-update-readme
Compute near far camera based on the bouding box of the 3D scene
Allow cross origin request from puppeteer