### PR TITLE
Release 3.0.0

### DIFF
--- a/docs/static/Devel/ReleasePublish.md
+++ b/docs/static/Devel/ReleasePublish.md
@@ -20,4 +20,4 @@ In order to publish the package to [npmjs](https://www.npmjs.com/) package repos
 
 1. Authenticate on npmjs with `npm login` and use the vcity account together with proper credentials.
    Note: because the npmjs authentication mode of the `vcity`account is currently configured to [One-Time-Password (OTP) over email](https://docs.npmjs.com/receiving-a-one-time-password-over-email) you will need to be part of the `vcity@liris.cnrs.fr` email alias forwarder to receive the OTP and be patient about it (the reception delay can be up to a couple minutes).
-1. `npm publish --workspace`
+1. `npm publish --workspaces`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack"
   },
+  "files": [
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/VCityTeam/UD-Viz.git"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,9 @@
     "test": "node --trace-warnings ./bin/test.js",
     "debug": "nodemon --trace-warnings --verbose --watch src --watch ./bin/Test/**/*.js --delay 2500ms ./bin/debug.js -e js"
   },
+  "files": [
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/VCityTeam/UD-Viz.git"


### PR DESCRIPTION
# v3.0.0

- JSDOC overhaul
- UD-Viz repository becomes a 3-package **mono-repo** :

  - Decompose the ud-viz package into 2 packages :
    - [@ud-viz/shared](https://github.com/VCityTeam/UD-Viz/tree/master/packages/shared)
    - [@ud-viz/browser](https://github.com/VCityTeam/UD-Viz/tree/master/packages/browser)
  - Add a new package
    - [@ud-viz/node](https://github.com/VCityTeam/UD-Viz/tree/master/packages/node)
  - 4 package.json: **mono-repo**, **browser**, **shared**, **node**
  - All eslint's warnings are fixed

- **browser**, **shared**: Add a set of tests for and scripts/features (html files in **browser** are tested with puppeteer)

- **browser**:

  - Delete `View3D` and `GameView`. The notion of View is now assured by `Frame3DBase` and `Frame3DPlanar`.
  - Creation of `ExternalContext`
  - All configs are now split by features
  - Widgets take as arguments their config and not allWidget config anymore
  - API breaking changes
  - Bug fixes for :
    - video loading
    - load texture files

- **shared**:

  - Delete `World`.
  - Refacto of `Context`
  - `GameObject` becomes `Object3D` and now extends `THREE.Object3D`

- **node**:

  - Write an `ExpressAppWrapper`

- **Documentation**:
  - 5 Readmes : **mono-repo**, **browser**, **shared**, **node**, **documentation**.
  - `Contributing.md`
  - `ReleasePublish.md` updated
