### PR TITLE
Add iTowns LabelLayers

### DIFF
--- a/packages/browser/examples/AllWidget.html
+++ b/packages/browser/examples/AllWidget.html
@@ -79,7 +79,8 @@
 
         udvizBrowser.addLabelLayers(
           configs['labels'],
-          frame3DPlanar.itownsView
+          frame3DPlanar.itownsView,
+          extent
         );
 
         // //// REQUEST SERVICE

--- a/packages/browser/examples/AllWidget.html
+++ b/packages/browser/examples/AllWidget.html
@@ -26,6 +26,7 @@
         './assets/config/layer/base_maps.json',
         './assets/config/layer/elevation.json',
         './assets/config/layer/geoJSONs.json',
+        './assets/config/layer/labels.json',
       ]).then((configs) => {
         // http://proj4js.org/
         // define a projection as a string and reference it that way
@@ -73,6 +74,11 @@
 
         udvizBrowser.addGeoJsonLayers(
           configs['geoJSONs'],
+          frame3DPlanar.itownsView
+        );
+
+        udvizBrowser.addLabelLayers(
+          configs['labels'],
           frame3DPlanar.itownsView
         );
 

--- a/packages/browser/examples/assets/config/layer/labels.json
+++ b/packages/browser/examples/assets/config/layer/labels.json
@@ -3,7 +3,6 @@
         "id": "Mairies de la métropole de Lyon",
         "url": "https://download.data.grandlyon.com/wfs/grandlyon?SERVICE=WFS&VERSION=2.0.0&request=GetFeature&typename=adr_voie_lieu.adrmairiepct_2_0_0&outputFormat=application/json;%20subtype=geojson&SRSNAME=EPSG:3946&startIndex=0",
         "sourceType": "file",
-        "crs": "EPSG:3946",
         "zoom": {
             "min": 3
         },
@@ -23,7 +22,6 @@
         "sourceType": "wfs",
         "version": "2.0.0",
         "name": "BDCARTO_BDD_WLD_WGS84G:zone_habitat_mairie",
-        "crs": "EPSG:3946",
         "format": "application/json",
         "zoom": {
             "min": 2

--- a/packages/browser/examples/assets/config/layer/labels.json
+++ b/packages/browser/examples/assets/config/layer/labels.json
@@ -1,0 +1,41 @@
+[
+    {
+        "id": "Mairies de la métropole de Lyon",
+        "url": "https://download.data.grandlyon.com/wfs/grandlyon?SERVICE=WFS&VERSION=2.0.0&request=GetFeature&typename=adr_voie_lieu.adrmairiepct_2_0_0&outputFormat=application/json;%20subtype=geojson&SRSNAME=EPSG:3946&startIndex=0",
+        "sourceType": "file",
+        "crs": "EPSG:3946",
+        "zoom": {
+            "min": 3
+        },
+        "style": {
+            "text": {
+                "field": "{nom}",
+                "color": "rgb(200,200,200)",
+                "size": 10,
+                "haloColor": "rgba(20,20,20, 0.8)",
+                "haloWidth": 3
+            }
+        }
+    },
+    {
+        "url": "https://wxs.ign.fr/cartovecto/geoportail/wfs?",
+        "id": "Quartiers",
+        "sourceType": "wfs",
+        "version": "2.0.0",
+        "name": "BDCARTO_BDD_WLD_WGS84G:zone_habitat_mairie",
+        "crs": "EPSG:3946",
+        "format": "application/json",
+        "zoom": {
+            "min": 2
+        },
+        "style": {
+            "text": {
+                "field": "{toponyme}",
+                "color": "rgb(255,255,255)",
+                "size": 15,
+                "haloColor": "rgba(20,20,20, 0.8)",
+                "haloWidth": 3
+            }
+        }
+    }
+]

--- a/packages/browser/src/Component/Itowns/AddLayerFromConfig.js
+++ b/packages/browser/src/Component/Itowns/AddLayerFromConfig.js
@@ -180,8 +180,9 @@ export function addGeoJsonLayers(configGeoJSONLayers, itownsView) {
  *
  * @param {object} configLabelLayers An object containing layers configs
  * @param {itowns.View} itownsView - the itowns view
+ * @param {itowns.Extent} extent extent of the view
  */
-export function addLabelLayers(configLabelLayers, itownsView) {
+export function addLabelLayers(configLabelLayers, itownsView, extent) {
   // Positional arguments verification
   if (!configLabelLayers) {
     console.warn('No "labelLayers" field in the configuration file');
@@ -195,7 +196,6 @@ export function addLabelLayers(configLabelLayers, itownsView) {
    * @param {string} layerConfig.sourceType The type of the source, should be either "file" or "wfs"
    * @param {object} layerConfig.style The iTowns style of the label layer
    * @param {string} layerConfig.url The URL of the layer
-   * @param {string} layerConfig.crs The CRS of the layer
    * @param {string} layerConfig.name If the source is WFS, the name of the source
    * @param {object} layerConfig.zoom The min/max zoom to display the layer
    */
@@ -203,11 +203,10 @@ export function addLabelLayers(configLabelLayers, itownsView) {
     if (
       !layerConfig['id'] ||
       !layerConfig['url'] ||
-      !layerConfig['crs'] ||
       !layerConfig['sourceType']
     ) {
       console.warn(
-        'Your "LabelLayer" field does not have either "url", "crs", "id" or "sourceType" properties. '
+        'Your "LabelLayer" field does not have either "url", "id" or "sourceType" properties. '
       );
       return;
     }
@@ -218,7 +217,7 @@ export function addLabelLayers(configLabelLayers, itownsView) {
     if (layerConfig['sourceType'] == 'file') {
       source = new itowns.FileSource({
         url: layerConfig.url,
-        crs: layerConfig.crs,
+        crs: extent.crs,
         format: 'application/json',
       });
     } else if (layerConfig['sourceType'] == 'wfs') {
@@ -226,7 +225,7 @@ export function addLabelLayers(configLabelLayers, itownsView) {
         url: layerConfig.url,
         version: '2.0.0',
         typeName: layerConfig.name,
-        crs: layerConfig.crs,
+        crs: extent.crs,
         format: 'application/json',
       });
     } else {

--- a/packages/browser/src/index.js
+++ b/packages/browser/src/index.js
@@ -43,6 +43,7 @@ export {
   addBaseMapLayer,
   addElevationLayer,
   addGeoJsonLayers,
+  addLabelLayers,
 } from './Component/Itowns/AddLayerFromConfig';
 
 // // Game


### PR DESCRIPTION
Method to set up and add LabelLayers in the itowns view.

The source of a LabelLayer can be either a WFS source or a File source.

The features in the source must be Point geometries.

Add an example in AllWidget example