### PR TITLE
update url

### DIFF
--- a/packages/browser/examples/assets/config/layer/doua_temporal.json
+++ b/packages/browser/examples/assets/config/layer/doua_temporal.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "La Doua temporel",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/la-doua_2009-2018-temporal_tileset/tileset.json",
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/Temporal/la-doua_2009-2018-temporal_tileset/tileset.json",
     "color": "0xFFFFFF",
     "extensions": ["3DTILES_temporal"]
   }


### PR DESCRIPTION
The [dataset server](https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/) is being cleaned up. This PR fixes a config that was pointing to an old link.