### PR TITLE
refact(Thread) runChildProcess is a method of Child

### DIFF
--- a/bin/gameThreadChildExamples.js
+++ b/bin/gameThreadChildExamples.js
@@ -3,4 +3,4 @@ const Thread = require('../packages/node/src/Game/Thread');
 const NoteGameManager = require('../packages/node/src/Game/ScriptTemplate/NoteGameManager');
 
 const child = new Thread.Child();
-child.run([Shared.Game.ScriptTemplate.NativeCommandManager, NoteGameManager]);
+child.start([Shared.Game.ScriptTemplate.NativeCommandManager, NoteGameManager]);

--- a/bin/gameThreadChildExamples.js
+++ b/bin/gameThreadChildExamples.js
@@ -1,8 +1,6 @@
 const Shared = require('@ud-viz/shared');
-const { runChildProcess } = require('../packages/node/src/Game/Thread');
+const Thread = require('../packages/node/src/Game/Thread');
 const NoteGameManager = require('../packages/node/src/Game/ScriptTemplate/NoteGameManager');
 
-runChildProcess([
-  Shared.Game.ScriptTemplate.NativeCommandManager,
-  NoteGameManager,
-]);
+const child = new Thread.Child();
+child.run([Shared.Game.ScriptTemplate.NativeCommandManager, NoteGameManager]);

--- a/packages/node/src/Game/ScriptTemplate/NoteGameManager.js
+++ b/packages/node/src/Game/ScriptTemplate/NoteGameManager.js
@@ -13,45 +13,52 @@ module.exports = class NoteGameManager extends Shared.Game.ScriptBase {
      @type {object} */
     this.socketObjects3D = {};
 
-    this.context.on(Game.Thread.EVENT.ON_NEW_SOCKET_WRAPPER, (socketID) => {
-      const pointerUUID = THREE.MathUtils.generateUUID();
+    this.context.on(
+      Game.Thread.MESSAGE_EVENT.ON_NEW_SOCKET_WRAPPER,
+      (socketID) => {
+        const pointerUUID = THREE.MathUtils.generateUUID();
 
-      const newSocketObject3D = new Shared.Game.Object3D({
-        static: true,
-        components: {
-          ExternalScript: {
-            idScripts: [
-              Shared.Game.ScriptTemplate.Constants.ID_SCRIPT.NoteSocketService,
-            ],
-            variables: {
-              socketID: socketID, // to know in external script this is the socket pointer
-              nameSocket: 'Default name',
-              pointerUUID: pointerUUID, // to easily ref pointer in NoteService script
+        const newSocketObject3D = new Shared.Game.Object3D({
+          static: true,
+          components: {
+            ExternalScript: {
+              idScripts: [
+                Shared.Game.ScriptTemplate.Constants.ID_SCRIPT
+                  .NoteSocketService,
+              ],
+              variables: {
+                socketID: socketID, // to know in external script this is the socket pointer
+                nameSocket: 'Default name',
+                pointerUUID: pointerUUID, // to easily ref pointer in NoteService script
+              },
             },
           },
-        },
-      });
+        });
 
-      const pointerObject3D = new Shared.Game.Object3D({
-        uuid: pointerUUID,
-        components: {
-          Render: {
-            idRenderData: 'sphere',
-            color: [Math.random(), Math.random(), Math.random(), 0.5],
+        const pointerObject3D = new Shared.Game.Object3D({
+          uuid: pointerUUID,
+          components: {
+            Render: {
+              idRenderData: 'sphere',
+              color: [Math.random(), Math.random(), Math.random(), 0.5],
+            },
           },
-        },
-      });
-      pointerObject3D.scale.set(50, 50, 50);
-      newSocketObject3D.add(pointerObject3D);
-      this.context.addObject3D(newSocketObject3D);
-      this.socketObjects3D[socketID] = newSocketObject3D;
-    });
+        });
+        pointerObject3D.scale.set(50, 50, 50);
+        newSocketObject3D.add(pointerObject3D);
+        this.context.addObject3D(newSocketObject3D);
+        this.socketObjects3D[socketID] = newSocketObject3D;
+      }
+    );
 
-    this.context.on(Game.Thread.EVENT.ON_SOCKET_WRAPPER_REMOVE, (socketID) => {
-      const object3DToRemove = this.socketObjects3D[socketID];
-      delete this.socketObjects3D[socketID];
-      this.context.removeObject3D(object3DToRemove.uuid);
-    });
+    this.context.on(
+      Game.Thread.MESSAGE_EVENT.ON_SOCKET_WRAPPER_REMOVE,
+      (socketID) => {
+        const object3DToRemove = this.socketObjects3D[socketID];
+        delete this.socketObjects3D[socketID];
+        this.context.removeObject3D(object3DToRemove.uuid);
+      }
+    );
   }
 
   tick() {

--- a/packages/node/src/Game/SocketService.js
+++ b/packages/node/src/Game/SocketService.js
@@ -99,13 +99,13 @@ const SocketService = class {
     gameObjects3D.forEach((gameObject3D) => {
       this.threads[gameObject3D.uuid] = new Thread.Parent(threadProcessPath);
       promises.push(
-        this.threads[gameObject3D.uuid].apply(Thread.EVENT.INIT, {
+        this.threads[gameObject3D.uuid].apply(Thread.MESSAGE_EVENT.INIT, {
           gameObject3D: gameObject3D,
         })
       );
 
       this.threads[gameObject3D.uuid].on(
-        Thread.EVENT.CURRENT_STATE,
+        Thread.MESSAGE_EVENT.CURRENT_STATE,
         (state) => {
           this.threads[gameObject3D.uuid].socketWrappers.forEach((sW) => {
             sW.sendState(state);

--- a/packages/node/src/Game/Thread.js
+++ b/packages/node/src/Game/Thread.js
@@ -199,7 +199,7 @@ class Child {
    *
    * @param {Object<string,Function>} gameScriptClass - class needs by object3D
    */
-  run(gameScriptClass = {}) {
+  start(gameScriptClass = {}) {
     // buffer
     let commands = null;
 

--- a/packages/node/src/Game/Thread.js
+++ b/packages/node/src/Game/Thread.js
@@ -12,7 +12,7 @@ const THREE = require('three');
 /**
  * Different Event between Parent and Child
  */
-const EVENT = {
+const MESSAGE_EVENT = {
   // parent => child
   INIT: 'init',
   COMMANDS: 'commands',
@@ -25,10 +25,14 @@ const EVENT = {
   APPLY_RESOLVE: 'apply_resolve',
 };
 
+const CHILD_EVENT = {
+  ON_GAME_CONTEXT_LOADED: 'on_game_context_loaded',
+};
+
 /**
  * Event message structure
  */
-const KEY = {
+const MESSAGE_KEY = {
   DATA: 0,
   TYPE: 1,
   APPLY_UUID: 2, // mean parent is waiting an answer from child to resolve apply promise
@@ -44,6 +48,9 @@ const Parent = class {
    * @param {string} threadProcessPath - path to the thread process
    */
   constructor(threadProcessPath) {
+    if (!workerThreads.isMainThread) {
+      throw new Error('Its not the main thread');
+    }
     /**
      *  worker
      * 
@@ -67,13 +74,15 @@ const Parent = class {
     // listen
     this.worker.on('message', (int32ArrayMessage) => {
       const objectMessage = Data.int32ArrayToObject(int32ArrayMessage);
-      if (this.callbacks[objectMessage[KEY.TYPE]]) {
-        this.callbacks[objectMessage[KEY.TYPE]](objectMessage[KEY.DATA]);
+      if (this.callbacks[objectMessage[MESSAGE_KEY.TYPE]]) {
+        this.callbacks[objectMessage[MESSAGE_KEY.TYPE]](
+          objectMessage[MESSAGE_KEY.DATA]
+        );
       }
     });
 
     // wait resolve signal from child thread
-    this.on(EVENT.APPLY_RESOLVE, (applyUUID) => {
+    this.on(MESSAGE_EVENT.APPLY_RESOLVE, (applyUUID) => {
       const resolve = this._resolveApply[applyUUID];
       if (!resolve) throw new Error('no resolve for ', applyUUID);
       resolve();
@@ -88,7 +97,7 @@ const Parent = class {
    */
   addSocketWrapper(socketWrapper) {
     this.socketWrappers.push(socketWrapper);
-    this.post(EVENT.ON_NEW_SOCKET_WRAPPER, socketWrapper.socket.id);
+    this.post(MESSAGE_EVENT.ON_NEW_SOCKET_WRAPPER, socketWrapper.socket.id);
 
     // reset last state of socket wrapper
     socketWrapper.lastStateSend = null;
@@ -100,7 +109,7 @@ const Parent = class {
     socketWrapper.socket.on(
       Constant.WEBSOCKET.MSG_TYPE.COMMANDS,
       (commands) => {
-        this.post(EVENT.COMMANDS, commands);
+        this.post(MESSAGE_EVENT.COMMANDS, commands);
       }
     );
   }
@@ -113,7 +122,7 @@ const Parent = class {
   removeSocketWrapper(socketWrapper) {
     const index = this.socketWrappers.indexOf(socketWrapper);
     if (index >= 0) this.socketWrappers.splice(index, 1);
-    this.post(EVENT.ON_SOCKET_WRAPPER_REMOVE, socketWrapper.socket.id);
+    this.post(MESSAGE_EVENT.ON_SOCKET_WRAPPER_REMOVE, socketWrapper.socket.id);
     socketWrapper.socket.removeAllListeners(
       Constant.WEBSOCKET.MSG_TYPE.COMMANDS
     );
@@ -129,8 +138,8 @@ const Parent = class {
    */
   post(msgType, data) {
     const object = {};
-    object[KEY.TYPE] = msgType;
-    object[KEY.DATA] = data;
+    object[MESSAGE_KEY.TYPE] = msgType;
+    object[MESSAGE_KEY.DATA] = data;
     this.worker.postMessage(Data.objectToInt32Array(object));
   }
 
@@ -155,10 +164,10 @@ const Parent = class {
   apply(msgType, data) {
     return new Promise((resolve) => {
       const object = {};
-      object[KEY.TYPE] = msgType;
-      object[KEY.DATA] = data;
+      object[MESSAGE_KEY.TYPE] = msgType;
+      object[MESSAGE_KEY.DATA] = data;
       const applyUUID = THREE.MathUtils.generateUUID();
-      object[KEY.APPLY_UUID] = applyUUID;
+      object[MESSAGE_KEY.APPLY_UUID] = applyUUID;
       this.worker.postMessage(Data.objectToInt32Array(object));
 
       this._resolveApply[applyUUID] = resolve;
@@ -166,142 +175,124 @@ const Parent = class {
   }
 };
 
-/** Code below is used in the thread child */
-
-/**
- * Run child process which can be summarize as so:
- * Listen {@link EVENT} of the parent and wait the gameobject
- * When gameobject is received launch a {@link Game.Context} and step it over time
- * Resolve {@link Child} so an user can customize this process with its own event
- *
- * @param {Object<string,Function>} gameScriptClass - class needs by object3D
- * @returns {Promise} - a promise resolving when game context is initialized and returning {@link Child}
- */
-function runChildProcess(gameScriptClass = {}) {
-  return new Promise((resolve) => {
-    if (workerThreads.isMainThread) {
-      throw new Error('Its not a worker');
-    }
-
-    const parentPort = workerThreads.parentPort;
-
-    const threadChild = new Child(parentPort);
-
-    /** @type {Game.Context} */
-    let gameContext = null;
-    let commands = null;
-
-    parentPort.on('message', (int32ArrayMessage) => {
-      const objectMessage = Data.int32ArrayToObject(int32ArrayMessage);
-      const data = objectMessage[KEY.DATA];
-      const applyUUID = objectMessage[KEY.APPLY_UUID];
-      const promises = [];
-
-      // dispatch for custom event & record promise associated for apply resolve
-      promises.push(threadChild.dispatch(objectMessage[KEY.TYPE], data));
-
-      switch (objectMessage[KEY.TYPE]) {
-        case EVENT.INIT:
-          gameContext = new Game.Context(
-            gameScriptClass,
-            new Game.Object3D(data.gameObject3D)
-          );
-
-          // init is not sync record promise
-          promises.push(
-            gameContext.load().then(() => {
-              const process = new ProcessInterval({ fps: 60 });
-              process.start((dt) => {
-                // simulation
-                gameContext.step(dt);
-                const currentState = gameContext.toState(false); // false because no need to send component already controlled
-                // post state to main thread
-                const message = {};
-                message[KEY.TYPE] = EVENT.CURRENT_STATE;
-                message[KEY.DATA] = currentState.toJSON();
-                parentPort.postMessage(Data.objectToInt32Array(message));
-              });
-
-              console.log(
-                'Child process ',
-                gameContext.object3D.name,
-                ' initialized',
-                gameContext.object3D.uuid
-              );
-
-              threadChild.initGameContext(gameContext);
-
-              resolve(threadChild);
-            })
-          );
-          break;
-        case EVENT.COMMANDS:
-          commands = [];
-          data.forEach(function (c) {
-            commands.push(new Command(c));
-          });
-          gameContext.onCommands(commands);
-          break;
-        case EVENT.ADD_OBJECT3D:
-          // add is not sync record in promises for apply
-          promises.push(
-            gameContext.addObject3D(
-              new Game.Object3D(data.object3D),
-              data.parentUUID
-            )
-          );
-          break;
-        case EVENT.REMOVE_OBJECT3D:
-          gameContext.removeObject3D(data);
-          break;
-        case EVENT.ON_NEW_SOCKET_WRAPPER:
-          gameContext.dispatch(EVENT.ON_NEW_SOCKET_WRAPPER, data);
-          break;
-        case EVENT.ON_SOCKET_WRAPPER_REMOVE:
-          gameContext.dispatch(EVENT.ON_SOCKET_WRAPPER_REMOVE, data);
-          break;
-        default:
-          console.warn(objectMessage[KEY.TYPE], ' not handle natively');
-      }
-
-      if (applyUUID) {
-        Promise.all(promises).then(() => {
-          const applyResolveMessage = {};
-          applyResolveMessage[KEY.TYPE] = EVENT.APPLY_RESOLVE;
-          applyResolveMessage[KEY.DATA] = applyUUID;
-          parentPort.postMessage(Data.objectToInt32Array(applyResolveMessage));
-        });
-      }
-    });
-  });
-}
-
 /**
  * @class class containing parentPort and a gameContext of a child thread {@link Child}
  * most of the time you want to use the method `on` to trigger event
  */
 class Child {
-  /**
-   *
-   * @param {workerThreads.MessagePort} parentPort - parent port of this thread
-   */
-  constructor(parentPort) {
+  constructor() {
+    if (workerThreads.isMainThread) {
+      throw new Error('Its not a worker');
+    }
+
     /** @type {Game.Context} */
     this.gameContext = null;
-
-    /** @type {workerThreads.MessagePort} */
-    this.parentPort = parentPort;
 
     /** @type {Object<string,Promise>} */
     this.promises = {};
   }
 
   /**
+   * Run child process which can be summarize as so:
+   * Listen {@link EVENT} of the parent and wait the gameobject
+   * When gameobject is received launch a {@link Game.Context} and step it over time
    *
-   * @param {Game.Context} value - game context of thread
+   * @param {Object<string,Function>} gameScriptClass - class needs by object3D
    */
-  initGameContext(value) {
-    this.gameContext = value;
+  run(gameScriptClass = {}) {
+    // buffer
+    let commands = null;
+
+    workerThreads.parentPort.on('message', (int32ArrayMessage) => {
+      const objectMessage = Data.int32ArrayToObject(int32ArrayMessage);
+      const data = objectMessage[MESSAGE_KEY.DATA];
+      const applyUUID = objectMessage[MESSAGE_KEY.APPLY_UUID];
+      const promises = [];
+
+      // dispatch for custom event & record promise associated for apply resolve
+      promises.push(this.dispatch(objectMessage[MESSAGE_KEY.TYPE], data));
+
+      switch (objectMessage[MESSAGE_KEY.TYPE]) {
+        case MESSAGE_EVENT.INIT:
+          this.gameContext = new Game.Context(
+            gameScriptClass,
+            new Game.Object3D(data.gameObject3D)
+          );
+
+          // init is not sync record promise
+          promises.push(
+            this.gameContext.load().then(() => {
+              const process = new ProcessInterval({ fps: 60 });
+              process.start((dt) => {
+                // simulation
+                this.gameContext.step(dt);
+                const currentState = this.gameContext.toState(false); // false because no need to send component already controlled
+                // post state to main thread
+                const message = {};
+                message[MESSAGE_KEY.TYPE] = MESSAGE_EVENT.CURRENT_STATE;
+                message[MESSAGE_KEY.DATA] = currentState.toJSON();
+                workerThreads.parentPort.postMessage(
+                  Data.objectToInt32Array(message)
+                );
+              });
+
+              console.log(
+                'Child process ',
+                this.gameContext.object3D.name,
+                ' initialized',
+                this.gameContext.object3D.uuid
+              );
+
+              this.dispatch(
+                CHILD_EVENT.ON_GAME_CONTEXT_LOADED,
+                this.gameContext
+              );
+            })
+          );
+          break;
+        case MESSAGE_EVENT.COMMANDS:
+          commands = [];
+          data.forEach(function (c) {
+            commands.push(new Command(c));
+          });
+          this.gameContext.onCommands(commands);
+          break;
+        case MESSAGE_EVENT.ADD_OBJECT3D:
+          // add is not sync record in promises for apply
+          promises.push(
+            this.gameContext.addObject3D(
+              new Game.Object3D(data.object3D),
+              data.parentUUID
+            )
+          );
+          break;
+        case MESSAGE_EVENT.REMOVE_OBJECT3D:
+          this.gameContext.removeObject3D(data);
+          break;
+        case MESSAGE_EVENT.ON_NEW_SOCKET_WRAPPER:
+          this.gameContext.dispatch(MESSAGE_EVENT.ON_NEW_SOCKET_WRAPPER, data);
+          break;
+        case MESSAGE_EVENT.ON_SOCKET_WRAPPER_REMOVE:
+          this.gameContext.dispatch(
+            MESSAGE_EVENT.ON_SOCKET_WRAPPER_REMOVE,
+            data
+          );
+          break;
+        default:
+          console.warn(objectMessage[MESSAGE_KEY.TYPE], ' not handle natively');
+      }
+
+      if (applyUUID) {
+        Promise.all(promises).then(() => {
+          const applyResolveMessage = {};
+          applyResolveMessage[MESSAGE_KEY.TYPE] = MESSAGE_EVENT.APPLY_RESOLVE;
+          applyResolveMessage[MESSAGE_KEY.DATA] = applyUUID;
+          workerThreads.parentPort.postMessage(
+            Data.objectToInt32Array(applyResolveMessage)
+          );
+        });
+      }
+    });
   }
 
   /**
@@ -317,12 +308,6 @@ class Child {
    * @param {PromiseListener|undefined} promise - callback return a promise or nothing
    */
   on(eventID, promise) {
-    for (const event in Parent.EVENT) {
-      if (EVENT[event] === eventID) {
-        throw new Error('native Thread event');
-      }
-    }
-
     this.promises[eventID] = promise;
   }
 
@@ -343,7 +328,7 @@ class Child {
 module.exports = {
   Parent: Parent,
   Child: Child,
-  runChildProcess: runChildProcess,
-  EVENT: EVENT,
-  KEY: KEY,
+  MESSAGE_EVENT: MESSAGE_EVENT,
+  MESSAGE_KEY: MESSAGE_KEY,
+  CHILD_EVENT: CHILD_EVENT,
 };


### PR DESCRIPTION
That was a bit weird to have runChildProcess out of Child class so I made a method and quite modify the api.
I rather dispatch an event ON_GAME_CONTEXT_LOADED instead of returning a Promise with the run method.

I also rename EVENT and KEY which are now MESSAGE_EVENT and MESSAGE_KEY where message is used to define what is send between child and parent in Thread.

Nothing functionally should have changed that's just to clarify stuff.