### PR TITLE
642 jsdoc html generation does not interpret mermaid

### DIFF
--- a/bin/docScriptTag.js
+++ b/bin/docScriptTag.js
@@ -1,7 +1,9 @@
+/** @file If first argument is `include` script tag are uncommented if nothing is passed script tag are commented */
+
 const fs = require('fs');
 const { Data } = require('@ud-viz/shared');
 
-const commentScriptTag = process.argv[2] == 'include';
+const includeScriptTag = process.argv[2] == 'include';
 
 const parseDirectory = (directoryPath) => {
   const dirents = fs.readdirSync(directoryPath, { withFileTypes: true });
@@ -9,16 +11,31 @@ const parseDirectory = (directoryPath) => {
     if (dirent.isFile() && Data.computeFileFormat(dirent.name) == 'md') {
       const filePath = directoryPath + '/' + dirent.name;
 
-      const contentMd = fs.readFileSync(filePath, {
+      // read contents of the file
+      const data = fs.readFileSync(filePath, {
         encoding: 'utf-8',
       });
 
-      console.log(filePath);
+      if (!includeScriptTag) {
+        fs.writeFileSync(
+          filePath,
+          data
+            .replace(/<script/g, '<!-- <script')
+            .replace(/script>/g, 'script> -->')
+        );
+      } else {
+        fs.writeFileSync(
+          filePath,
+          data
+            .replace(/<!-- <script/g, '<script')
+            .replace(/script> -->/g, 'script>')
+        );
+      }
     } else if (dirent.isDirectory()) {
       parseDirectory(directoryPath + '/' + dirent.name); // recursive
     }
   });
 };
 
-console.log(`\nComment script tag: ${commentScriptTag}\n`);
+console.log(`\nInclude script tag: ${includeScriptTag}\n`);
 parseDirectory('./docs/static');

--- a/bin/docScriptTag.js
+++ b/bin/docScriptTag.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const { Data } = require('@ud-viz/shared');
+
+const commentScriptTag = process.argv[2] == 'include';
+
+const parseDirectory = (directoryPath) => {
+  const dirents = fs.readdirSync(directoryPath, { withFileTypes: true });
+  dirents.forEach((dirent) => {
+    if (dirent.isFile() && Data.computeFileFormat(dirent.name) == 'md') {
+      const filePath = directoryPath + '/' + dirent.name;
+
+      const contentMd = fs.readFileSync(filePath, {
+        encoding: 'utf-8',
+      });
+
+      console.log(filePath);
+    } else if (dirent.isDirectory()) {
+      parseDirectory(directoryPath + '/' + dirent.name); // recursive
+    }
+  });
+};
+
+console.log(`\nComment script tag: ${commentScriptTag}\n`);
+parseDirectory('./docs/static');

--- a/docs/js/jsdoc-tuts-mermaid.js
+++ b/docs/js/jsdoc-tuts-mermaid.js
@@ -1,0 +1,38 @@
+/**
+ *
+ */
+function renderMermaidLangs() {
+  [...document.querySelectorAll('.lang-mermaid')].forEach(
+    (markdownGraphEl, i) => {
+      const graphDefinition = markdownGraphEl.innerText;
+
+      const cb = function (graphHTML) {
+        const graphContainerEl = document.createElement('div');
+        graphContainerEl.innerHTML = graphHTML;
+        const graphEl = graphContainerEl.querySelector('svg');
+
+        graphEl.style.display = 'block';
+        graphEl.style.margin = '0 auto';
+        graphContainerEl.style.margin = '50px 0';
+
+        markdownGraphEl.replaceWith(graphContainerEl);
+      };
+
+      window.mermaid.render(`mermaid_graph_${i}`, graphDefinition, cb);
+    }
+  );
+}
+
+/**
+ *
+ */
+function loadMermaid() {
+  const mermaidjs = document.createElement('script');
+  mermaidjs.src =
+    'https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.9.0/mermaid.min.js';
+  document.body.appendChild(mermaidjs);
+
+  mermaidjs.addEventListener('load', renderMermaidLangs);
+}
+
+document.addEventListener('DOMContentLoaded', loadMermaid);

--- a/docs/jsdocConfig/jsdoc.common.json
+++ b/docs/jsdocConfig/jsdoc.common.json
@@ -13,6 +13,9 @@
     "monospaceLinks": true,
     "search": true,
     "default": {
+      "staticFiles": {
+        "include": ["./docs/js"]
+      },
       "includeDate": true,
       "useLongnameInNav": false
     }

--- a/docs/static/Devel/UD_Viz_Browser/ud_viz_browser.md
+++ b/docs/static/Devel/UD_Viz_Browser/ud_viz_browser.md
@@ -2,7 +2,7 @@ This is the entry points for @ud-viz/browser tutorials
 
 # Dependency graph overview
 
-<script src="./jsdoc-tuts-mermaid.js"></script>
+<!-- <script src="./jsdoc-tuts-mermaid.js"></script> -->
 
 ```mermaid
 flowchart LR

--- a/docs/static/Devel/UD_Viz_Browser/ud_viz_browser.md
+++ b/docs/static/Devel/UD_Viz_Browser/ud_viz_browser.md
@@ -1,1 +1,33 @@
 This is the entry points for @ud-viz/browser tutorials
+
+# Dependency graph overview
+
+<script src="./jsdoc-tuts-mermaid.js"></script>
+
+```mermaid
+flowchart LR
+AssetManager
+Game
+Frame3D
+Widget
+ItownsUtil
+HTMLUtil
+InputManager
+RequestAnimationFrame
+RequestService
+SocketIOWrapper
+THREEUtil
+FileUtil
+GUI
+AssetManager --> THREEUtil
+Frame3D --> THREEUtil
+Frame3D --> HTMLUtil
+Widget --> RequestService
+Widget --> HTMLUtil
+Widget --> ItownsUtil
+Game --> AssetManager
+Game --> Frame3D
+Game --> InputManager
+Game --> SocketIOWrapper
+Game --> RequestAnimationFrame
+```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docs-browser": "cross-env PACKAGE=browser jsdoc -c ./docs/jsdocConfig/jsdoc.js",
     "docs-node": "cross-env PACKAGE=node jsdoc -c ./docs/jsdocConfig/jsdoc.js",
     "docs-home": "cross-env PACKAGE=home jsdoc -c ./docs/jsdocConfig/jsdoc.js",
-    "docs": "rm -rf ./docs/html && node ./bin/docScriptTag.js include && npm run docs-browser ; npm run docs-node ; npm run docs-shared ; npm run docs-home",
+    "docs": "rm -rf ./docs/html && node ./bin/docScriptTag.js include && npm run docs-browser ; npm run docs-node ; npm run docs-shared ; npm run docs-home && node ./bin/docScriptTag.js",
     "dev-docs": "nodemon --watch ./packages/shared/src --watch ./packages/browser/src --watch ./packages/node/src --delay 2500ms --exec npm run docs",
     "back-end-examples": "cross-env NODE_ENV=production node ./bin/backEndExamples.js",
     "start": "npm run build-browser && npm run back-end-examples"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docs-browser": "cross-env PACKAGE=browser jsdoc -c ./docs/jsdocConfig/jsdoc.js",
     "docs-node": "cross-env PACKAGE=node jsdoc -c ./docs/jsdocConfig/jsdoc.js",
     "docs-home": "cross-env PACKAGE=home jsdoc -c ./docs/jsdocConfig/jsdoc.js",
-    "docs": "rm -rf ./docs/html && npm run docs-browser ; npm run docs-node ; npm run docs-shared ; npm run docs-home",
+    "docs": "rm -rf ./docs/html && node ./bin/docScriptTag.js include && npm run docs-browser ; npm run docs-node ; npm run docs-shared ; npm run docs-home",
     "dev-docs": "nodemon --watch ./packages/shared/src --watch ./packages/browser/src --watch ./packages/node/src --delay 2500ms --exec npm run docs",
     "back-end-examples": "cross-env NODE_ENV=production node ./bin/backEndExamples.js",
     "start": "npm run build-browser && npm run back-end-examples"


### PR DESCRIPTION
This PR allow to render mermaid graph for the jsdoc generated documentation you can see it at this url http://localhost:8000/docs/html/node/tutorial-ud_viz_browser.html after running `npm run docs`

Note that a script uncomment script tag before doc generation then comment them (to import mermaid script during doc generation then to make the script invisible on github) 