### PR TITLE
Use 2018 buildings

### DIFF
--- a/examples/assets/config/layer/3DTiles.json
+++ b/examples/assets/config/layer/3DTiles.json
@@ -1,34 +1,38 @@
 [
   {
     "id": "Lyon-1",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-1_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-1_2018/tileset.json"
   },
   {
     "id": "Lyon-2",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-2_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-2_2018/tileset.json"
   },
   {
     "id": "Lyon-3",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-3_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-3_2018/tileset.json"
   },
   {
     "id": "Lyon-4",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-4_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-4_2018/tileset.json"
   },
   {
     "id": "Lyon-5",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-5_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-5_2018/tileset.json"
   },
   {
     "id": "Lyon-6",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-6_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-6_2018/tileset.json"
   },
   {
     "id": "Lyon-7",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-7_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-7_2018/tileset.json"
   },
   {
     "id": "Lyon-8",
-    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2015/Lyon-8_2015/tileset.json"
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-8_2018/tileset.json"
+  },
+  {
+    "id": "Lyon-9",
+    "url": "https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/Lyon-9_2018/tileset.json"
   }
 ]


### PR DESCRIPTION
Use 2018 buildings instead of 2015 buildings, some triangles are missing in 2015 3DTiles because they were created with an old version of py3dtilers

2015

![image](https://github.com/VCityTeam/UD-Viz/assets/32875283/546cbf33-386b-4631-898b-7e2ae923f7f0)

2018

![image](https://github.com/VCityTeam/UD-Viz/assets/32875283/6ad08ca0-6451-4fbc-8f38-3946a4669388)

(I've created Lyon1 --> Lyon9 2018, those tilesets are available on [3DTiles liris](https://dataset-dl.liris.cnrs.fr/three-d-tiles-lyon-metropolis/2018/))