### PR TITLE
LayerChoice Widget: Re-enabling the focus button in the LayerChoice widget

### DIFF
--- a/packages/utils_browser/src/itownsUtil.js
+++ b/packages/utils_browser/src/itownsUtil.js
@@ -8,9 +8,10 @@ const itowns = require('itowns');
 /**
  * Compute a distance automatically for travel features of itowns Planar View
  *
+ * @note Code retrieve itowns - {@link https://github.com/iTowns/itowns/blob/1bad0d627764c73b606179c636ad7b70105dd633/src/Controls/PlanarControls.js#L712}
  * @param {itowns.PlanarControls} controls - planar controls of itownsView
  * @param {THREE.Vector3} targetPos - position of our target
- * @returns {number} - the duration of travel to focus a targetPosition
+ * @returns {number} the duration of travel to focus a targetPosition
  */
 function autoDurationTravel(controls, targetPos) {
   const normalizedDistance = Math.min(

--- a/packages/utils_browser/src/itownsUtil.js
+++ b/packages/utils_browser/src/itownsUtil.js
@@ -8,7 +8,8 @@ const itowns = require('itowns');
 /**
  * Compute a distance automatically for travel features of itowns Planar View
  *
- * @note Code retrieve itowns - {@link https://github.com/iTowns/itowns/blob/1bad0d627764c73b606179c636ad7b70105dd633/src/Controls/PlanarControls.js#L712}
+ * Note: Code retrieve itowns - {@link https://github.com/iTowns/itowns/blob/1bad0d627764c73b606179c636ad7b70105dd633/src/Controls/PlanarControls.js#L712}
+ *
  * @param {itowns.PlanarControls} controls - planar controls of itownsView
  * @param {THREE.Vector3} targetPos - position of our target
  * @returns {number} the duration of travel to focus a targetPosition

--- a/packages/widget_layer_choice/src/index.js
+++ b/packages/widget_layer_choice/src/index.js
@@ -2,6 +2,7 @@ import {
   createLocalStorageCheckbox,
   createLocalStorageDetails,
   createLocalStorageSlider,
+  focusC3DTilesLayer,
 } from '@ud-viz/utils_browser';
 
 import { PointsMaterial } from 'three';
@@ -99,6 +100,15 @@ export class LayerChoice {
         param.layer.visible = visibleInput.checked;
         this.view.notifyChange(this.view.camera.camera3D);
       };
+
+      if (param.layer.isC3DTilesLayer) {
+        const focusButton = document.createElement('button');
+        focusButton.innerText = 'Focus';
+        layerContainerDomElement.appendChild(focusButton);
+        focusButton.onclick = () => {
+          focusC3DTilesLayer(this.view, param.layer);
+        };
+      }
 
       // opacity checkbox
       const opacityInput = createLocalStorageSlider(


### PR DESCRIPTION
A button used to focus the camera closer to a layer that is a c3dtilesLayer.

Welcome back focus button!