### PR TITLE
Fix/document/make-configurable the role of the pop up dialog

### DIFF
--- a/packages/point_cloud_visualizer/src/index.js
+++ b/packages/point_cloud_visualizer/src/index.js
@@ -635,7 +635,6 @@ export class PointCloudVisualizer {
       this.itownsView.scene.add(quad);
 
       if (
-        confirm('Voulez-vous recharger le plan ?') &&
         localStorageSetMatrix4(
           quad.matrixWorld,
           'point_cloud_visualizer_quad_matrix4'


### PR DESCRIPTION
On starting page, a popup asks for some confirmation "of map reloading" (the question asked in "french", 
ooops, goes "Voulez-vous recharger le plan ?").
The purpose of the question is not documented : in which way is the behavior of the application
changed depending on the answer given ?

Note: it seems the behavior is Chrome/Firefox dependent.

How to improve things (from quick and dirty to clean way)
1. remove this PITA pop up
2. document (in the UI so the user does understand) the purpose of the question
    In fact the question should be "Voulez-vous recharger la position du plan de coupe?" 
     which in english goes something like "Do you want to restore the clipping plane position to its modified position or should the default position be restored?" (make the question shorter and clearer of course)
3. make that popup an option (as creation stage) that is controlled by the caller
4. THE RECOMMENDABLE WAY: Remove the pop-up AND instead provide a 
   "reset position" button within the "Clipping plane" tab entry of the widget.

Additionally, document (source level) what the quad object is for (a flat plane that "materializes" the clipping plane position). 