### PR TITLE
Update ReleasePublish.md

### DIFF
--- a/docs/static/ReleasePublish.md
+++ b/docs/static/ReleasePublish.md
@@ -42,7 +42,7 @@
 
 To publish the package to [npmjs](https://www.npmjs.com/) package repository
 
-1. Authenticate on npmjs with `npm login` and use the vcity account together with proper credentials. 
+1. Authenticate on npmjs with `npm login --auth-type=legacy` and use the vcity account together with proper credentials. 
    Note:
    - Ask username and password to login at an admin
    - Because the npmjs authentication mode of the `vcity`account is currently configured to [One-Time-Password (OTP) over email](https://docs.npmjs.com/receiving-a-one-time-password-over-email) you will need to be part of the `vcity@liris.cnrs.fr` email alias forwarder to receive the OTP and be patient about it (the reception delay can be up to a couple minutes).


### PR DESCRIPTION
While authentification on npm js is with opt way, we need to set `auth-type` option to legacy.

SEE : https://docs.npmjs.com/cli/v9/commands/npm-login#auth-type